### PR TITLE
libc: fix build in C23 mode

### DIFF
--- a/lib/libc/include/stdbool.h
+++ b/lib/libc/include/stdbool.h
@@ -13,7 +13,7 @@
 #ifndef _STDBOOL_H
 #define _STDBOOL_H
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) && __STDC_VERSION__ < 202311L
 typedef enum { false = 0, true } bool;
 #endif
 


### PR DESCRIPTION
GCC 15 defaults to C23, in which bool, true, and false are keywords.
